### PR TITLE
Added netstandard2.1 build target & support for Span<>

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![NuGet](https://img.shields.io/nuget/v/CRC.Fast.Net.Core "Download from NuGet")](https://www.nuget.org/packages/CRC.Fast.Net.Core)
+
 # FastCRC
 Fast CRC dot.net implementation
 There is adopted version of C++ fast Crc32 algorithm "Slicing-by-16" (c) Stephan Brumme & Bulat Ziganshin

--- a/UnitTest/CRCTest.cs
+++ b/UnitTest/CRCTest.cs
@@ -24,6 +24,22 @@ namespace UnitTest
             }
         }
 
+#if NETCOREAPP3_0
+        [TestMethod]
+        public void DataTestSpan()
+        {
+            string dataFile = "CRC32Data.txt";
+            var testData = LoadTestData(dataFile);
+
+            Assert.AreEqual(1025, testData.Count);
+            for (int i = 0; i < testData.Count; ++i)
+            {
+                uint crc = CRC.Crc32(testData[i].Item1.AsSpan());
+                Assert.AreEqual(testData[i].Item2, crc, $"Line {i}");
+            }
+        }
+#endif
+
         [TestMethod]
         public void Test42()
         {
@@ -33,6 +49,18 @@ namespace UnitTest
             uint crc = CRC.Crc32(Encoding.ASCII.GetBytes(text));
             Assert.AreEqual(textCRC32, crc);
         }
+
+#if NETCOREAPP3_0
+        [TestMethod]
+        public void Test42Span()
+        {
+            string text = "Answer to the Ultimate Question of Life, the Universe, and Everything";
+            uint textCRC32 = 0xf341b721;
+
+            uint crc = CRC.Crc32(Encoding.ASCII.GetBytes(text).AsSpan());
+            Assert.AreEqual(textCRC32, crc);
+        }
+#endif
 
         private static List<Tuple<byte[], uint>> LoadTestData(string dataFile)
         {

--- a/UnitTest/CRCTest.cs
+++ b/UnitTest/CRCTest.cs
@@ -24,7 +24,6 @@ namespace UnitTest
             }
         }
 
-#if NETCOREAPP3_0
         [TestMethod]
         public void DataTestSpan()
         {
@@ -38,7 +37,6 @@ namespace UnitTest
                 Assert.AreEqual(testData[i].Item2, crc, $"Line {i}");
             }
         }
-#endif
 
         [TestMethod]
         public void Test42()
@@ -50,7 +48,6 @@ namespace UnitTest
             Assert.AreEqual(textCRC32, crc);
         }
 
-#if NETCOREAPP3_0
         [TestMethod]
         public void Test42Span()
         {
@@ -60,7 +57,6 @@ namespace UnitTest
             uint crc = CRC.Crc32(Encoding.ASCII.GetBytes(text).AsSpan());
             Assert.AreEqual(textCRC32, crc);
         }
-#endif
 
         private static List<Tuple<byte[], uint>> LoadTestData(string dataFile)
         {

--- a/UnitTest/UnitTest.csproj
+++ b/UnitTest/UnitTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/UnitTest/UnitTest.csproj
+++ b/UnitTest/UnitTest.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/CRC.cs
+++ b/src/CRC.cs
@@ -10,7 +10,7 @@ namespace Soft160.Data.Cryptography
     /// Perf tests : this implemenation is just little bit slower (about 10%) than native CLI C++ fast Crc32 implemenation:
     /// 96 buffers by 128MB (12GB) data - 5.293 seconds vs 4.910 seconds
     /// </summary>
-    public class CRC
+    public static class CRC
     {
         //private static readonly Func<byte[], int, int, uint, uint> ALGORITHM_FUNCTION = BitConverter.IsLittleEndian ? (Func<byte[], int, int, uint, uint>)Crc32LittleEndian : Crc32BigEndian;
 

--- a/src/CRC.cs
+++ b/src/CRC.cs
@@ -15,7 +15,7 @@ namespace Soft160.Data.Cryptography
         //private static readonly Func<byte[], int, int, uint, uint> ALGORITHM_FUNCTION = BitConverter.IsLittleEndian ? (Func<byte[], int, int, uint, uint>)Crc32LittleEndian : Crc32BigEndian;
 
 #if NETCOREAPP2_1
-        public static uint Crc32(Span<byte> data, uint previousCrc32 = 0) => Crc32(data, 0, data.Length, previousCrc32);
+        public static uint Crc32(ReadOnlySpan<byte> data, uint previousCrc32 = 0) => Crc32(data, 0, data.Length, previousCrc32);
 #endif
 
         public static uint Crc32(byte[] data, uint previousCrc32 = 0) => Crc32(data, 0, data.Length, previousCrc32);
@@ -25,17 +25,15 @@ namespace Soft160.Data.Cryptography
             Crc32(data.AsSpan(), offset, count, previousCrc32);
 #endif
 
-        public static uint Crc32(
 #if NETCOREAPP2_1
-            Span<byte> data
+        public static uint Crc32(ReadOnlySpan<byte> data, int offset, int count, uint previousCrc32 = 0)
 #else
-            byte[] data
+        public static uint Crc32(byte[] data, int offset, int count, uint previousCrc32 = 0)
 #endif
-            , int offset, int count, uint previousCrc32 = 0)
         {
             if (data == null)
             {
-                throw new ArgumentNullException();
+                throw new ArgumentNullException(nameof(data));
             }
             if (offset < 0 || count < 0)
             {
@@ -49,17 +47,15 @@ namespace Soft160.Data.Cryptography
             return BitConverter.IsLittleEndian ? Crc32LittleEndian(data, offset, count, previousCrc32) : Crc32BigEndian(data, offset, count, previousCrc32);
         }
 
-        private static uint Crc32LittleEndian(
 #if NETCOREAPP2_1
-            Span<byte> data
+        private static uint Crc32LittleEndian(ReadOnlySpan<byte> data, int offset, int count, uint previousCrc32)
 #else
-            byte[] data
+        private static uint Crc32LittleEndian(byte[] data, int offset, int count, uint previousCrc32)
 #endif
-            , int offset, int count, uint previousCrc32)
         {
             uint crc = ~previousCrc32; // same as previousCrc32 ^ 0xFFFFFFFF
-            int unroll = 4;
-            int bytesAtOnce = 16 * unroll;
+            const int unroll = 4;
+            const int bytesAtOnce = 16 * unroll;
 
             unsafe
             {
@@ -68,7 +64,7 @@ namespace Soft160.Data.Cryptography
                 {
                     byte* bytePtr = dataPtr + offset;
                     uint* uintPtr = (uint*)bytePtr;
-                    uint* uintEndPtr = uintPtr + (count / bytesAtOnce) * (bytesAtOnce / 4);
+                    uint* uintEndPtr = uintPtr + (count / bytesAtOnce * (bytesAtOnce / 4));
 
                     uint* lookup_1 = lookup_0 + 0x100;
                     uint* lookup_2 = lookup_0 + 0x200;
@@ -95,22 +91,22 @@ namespace Soft160.Data.Cryptography
                             uint two = *uintPtr++;
                             uint three = *uintPtr++;
                             uint four = *uintPtr++;
-                            crc = lookup_0[(four >> 24) & 0xFF] ^
-                                lookup_1[(four >> 16) & 0xFF] ^
-                                lookup_2[(four >> 8) & 0xFF] ^
-                                lookup_3[four & 0xFF] ^
-                                lookup_4[(three >> 24) & 0xFF] ^
-                                lookup_5[(three >> 16) & 0xFF] ^
-                                lookup_6[(three >> 8) & 0xFF] ^
-                                lookup_7[three & 0xFF] ^
-                                lookup_8[(two >> 24) & 0xFF] ^
-                                lookup_9[(two >> 16) & 0xFF] ^
-                                lookup_10[(two >> 8) & 0xFF] ^
-                                lookup_11[two & 0xFF] ^
-                                lookup_12[(one >> 24) & 0xFF] ^
-                                lookup_13[(one >> 16) & 0xFF] ^
-                                lookup_14[(one >> 8) & 0xFF] ^
-                                lookup_15[one & 0xFF];
+                            crc = lookup_0[(four >> 24) & 0xFF]
+                                ^ lookup_1[(four >> 16) & 0xFF]
+                                ^ lookup_2[(four >> 8) & 0xFF]
+                                ^ lookup_3[four & 0xFF]
+                                ^ lookup_4[(three >> 24) & 0xFF]
+                                ^ lookup_5[(three >> 16) & 0xFF]
+                                ^ lookup_6[(three >> 8) & 0xFF]
+                                ^ lookup_7[three & 0xFF]
+                                ^ lookup_8[(two >> 24) & 0xFF]
+                                ^ lookup_9[(two >> 16) & 0xFF]
+                                ^ lookup_10[(two >> 8) & 0xFF]
+                                ^ lookup_11[two & 0xFF]
+                                ^ lookup_12[(one >> 24) & 0xFF]
+                                ^ lookup_13[(one >> 16) & 0xFF]
+                                ^ lookup_14[(one >> 8) & 0xFF]
+                                ^ lookup_15[one & 0xFF];
                         }
                     }
 
@@ -126,17 +122,15 @@ namespace Soft160.Data.Cryptography
             return ~crc; // same as crc ^ 0xFFFFFFFF
         }
 
-        private static uint Crc32BigEndian(
 #if NETCOREAPP2_1
-            Span<byte> data
+        private static uint Crc32BigEndian(ReadOnlySpan<byte> data, int offset, int count, uint previousCrc32)
 #else
-            byte[] data
+        private static uint Crc32BigEndian(byte[] data, int offset, int count, uint previousCrc32)
 #endif
-            , int offset, int count, uint previousCrc32)
         {
             uint crc = ~previousCrc32; // same as previousCrc32 ^ 0xFFFFFFFF
-            int unroll = 4;
-            int bytesAtOnce = 16 * unroll;
+            const int unroll = 4;
+            const int bytesAtOnce = 16 * unroll;
 
             unsafe
             {
@@ -145,7 +139,7 @@ namespace Soft160.Data.Cryptography
                 {
                     byte* bytePtr = dataPtr + offset;
                     uint* uintPtr = (uint*)bytePtr;
-                    uint* uintEndPtr = uintPtr + (count / bytesAtOnce) * (bytesAtOnce / 4);
+                    uint* uintEndPtr = uintPtr + (count / bytesAtOnce * (bytesAtOnce / 4));
 
                     uint* lookup_1 = lookup_0 + 0x100;
                     uint* lookup_2 = lookup_0 + 0x200;
@@ -172,28 +166,28 @@ namespace Soft160.Data.Cryptography
                             uint two = *uintPtr++;
                             uint three = *uintPtr++;
                             uint four = *uintPtr++;
-                            crc = lookup_0[four & 0xFF] ^
-                                lookup_1[(four >> 8) & 0xFF] ^
-                                lookup_2[(four >> 16) & 0xFF] ^
-                                lookup_3[(four >> 24) & 0xFF] ^
-                                lookup_4[three & 0xFF] ^
-                                lookup_5[(three >> 8) & 0xFF] ^
-                                lookup_6[(three >> 16) & 0xFF] ^
-                                lookup_7[(three >> 24) & 0xFF] ^
-                                lookup_8[two & 0xFF] ^
-                                lookup_9[(two >> 8) & 0xFF] ^
-                                lookup_10[(two >> 16) & 0xFF] ^
-                                lookup_11[(two >> 24) & 0xFF] ^
-                                lookup_12[one & 0xFF] ^
-                                lookup_13[(one >> 8) & 0xFF] ^
-                                lookup_14[(one >> 16) & 0xFF] ^
-                                lookup_15[(one >> 24) & 0xFF];
+                            crc = lookup_0[four & 0xFF]
+                                ^ lookup_1[(four >> 8) & 0xFF]
+                                ^ lookup_2[(four >> 16) & 0xFF]
+                                ^ lookup_3[(four >> 24) & 0xFF]
+                                ^ lookup_4[three & 0xFF]
+                                ^ lookup_5[(three >> 8) & 0xFF]
+                                ^ lookup_6[(three >> 16) & 0xFF]
+                                ^ lookup_7[(three >> 24) & 0xFF]
+                                ^ lookup_8[two & 0xFF]
+                                ^ lookup_9[(two >> 8) & 0xFF]
+                                ^ lookup_10[(two >> 16) & 0xFF]
+                                ^ lookup_11[(two >> 24) & 0xFF]
+                                ^ lookup_12[one & 0xFF]
+                                ^ lookup_13[(one >> 8) & 0xFF]
+                                ^ lookup_14[(one >> 16) & 0xFF]
+                                ^ lookup_15[(one >> 24) & 0xFF];
                         }
                     }
 
                     // remaining 1 to 63 bytes (standard algorithm)
                     int restBytes = count % bytesAtOnce;
-                    for (int i = (count / bytesAtOnce) * bytesAtOnce; i < count;)
+                    for (int i = count / bytesAtOnce * bytesAtOnce; i < count;)
                     {
                         crc = (crc >> 8) ^ lookup_0[(crc & 0xFF) ^ bytePtr[i++]];
                     }
@@ -203,13 +197,15 @@ namespace Soft160.Data.Cryptography
             return ~crc; // same as crc ^ 0xFFFFFFFF
         }
 
+        /// <summary>
         /// swap endianess
+        /// </summary>
         internal static uint Swap(uint x)
         {
-            return (x >> 24) |
-                ((x >> 8) & 0x0000FF00) |
-                ((x << 8) & 0x00FF0000) |
-                (x << 24);
+            return (x >> 24)
+                | ((x >> 8) & 0x0000FF00)
+                | ((x << 8) & 0x00FF0000)
+                | (x << 24);
         }
 
         private static readonly uint[] Crc32Lookup = new uint[]

--- a/src/CRC.cs
+++ b/src/CRC.cs
@@ -14,19 +14,19 @@ namespace Soft160.Data.Cryptography
     {
         //private static readonly Func<byte[], int, int, uint, uint> ALGORITHM_FUNCTION = BitConverter.IsLittleEndian ? (Func<byte[], int, int, uint, uint>)Crc32LittleEndian : Crc32BigEndian;
 
-#if NETSTANDARD2_1
+#if NETCOREAPP2_1
         public static uint Crc32(Span<byte> data, uint previousCrc32 = 0) => Crc32(data, 0, data.Length, previousCrc32);
 #endif
 
         public static uint Crc32(byte[] data, uint previousCrc32 = 0) => Crc32(data, 0, data.Length, previousCrc32);
 
-#if NETSTANDARD2_1
+#if NETCOREAPP2_1
         public static uint Crc32(byte[] data, int offset, int count, uint previousCrc32 = 0) =>
             Crc32(data.AsSpan(), offset, count, previousCrc32);
 #endif
 
         public static uint Crc32(
-#if NETSTANDARD2_1
+#if NETCOREAPP2_1
             Span<byte> data
 #else
             byte[] data
@@ -50,7 +50,7 @@ namespace Soft160.Data.Cryptography
         }
 
         private static uint Crc32LittleEndian(
-#if NETSTANDARD2_1
+#if NETCOREAPP2_1
             Span<byte> data
 #else
             byte[] data
@@ -127,7 +127,7 @@ namespace Soft160.Data.Cryptography
         }
 
         private static uint Crc32BigEndian(
-#if NETSTANDARD2_1
+#if NETCOREAPP2_1
             Span<byte> data
 #else
             byte[] data

--- a/src/CRC.csproj
+++ b/src/CRC.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net40;netstandard2.0;netstandard2.1;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net40;netstandard2.0;netstandard2.1</TargetFrameworks>
     <OutputType>Library</OutputType>
     <RootNamespace>Soft160.Data.Cryptography</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/CRC.csproj
+++ b/src/CRC.csproj
@@ -5,13 +5,14 @@
     <RootNamespace>Soft160.Data.Cryptography</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>Soft160.Data.Cryptography</AssemblyName>
-    <PackageId>CRC.Fast.Net</PackageId>
+    <PackageId>CRC.Fast.Net.Core</PackageId>
     <Authors>Yuri Babich</Authors>
     <Product>Fast CRC dotnet Library</Product>
     <Description>Really fast CRC implementation.
-It's faster than popular CRC Nuget packages 1.5-20 times</Description>
+It's faster than popular CRC Nuget packages 1.5-20 times
+With support for Span&lt;T&gt;</Description>
     <Copyright>Yuri Babich</Copyright>
-    <PackageProjectUrl>https://github.com/yubabich/FastCRC</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/craig-b/FastCRC</PackageProjectUrl>
     <PackageTags>CRC, CRC32, Fast CRC</PackageTags>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Version>1.0.0</Version>

--- a/src/CRC.csproj
+++ b/src/CRC.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net40;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net40;netstandard2.0;netcoreapp2.1</TargetFrameworks>
     <OutputType>Library</OutputType>
     <RootNamespace>Soft160.Data.Cryptography</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/CRC.csproj
+++ b/src/CRC.csproj
@@ -1,6 +1,6 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net40;netstandard2.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net40;netstandard2.0;netstandard2.1;netcoreapp2.1</TargetFrameworks>
     <OutputType>Library</OutputType>
     <RootNamespace>Soft160.Data.Cryptography</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/CRCServiceProvider.cs
+++ b/src/CRCServiceProvider.cs
@@ -16,10 +16,11 @@ namespace Soft160.Data.Cryptography
             HashSizeValue = 32;
         }
 
-        protected override void HashCore(byte[] array, int ibStart, int cbSize)
-        {
-            seed = CRC.Crc32(array, ibStart, cbSize, seed);
-        }
+        protected override void HashCore(byte[] array, int ibStart, int cbSize) => seed = CRC.Crc32(array, ibStart, cbSize, seed);
+
+#if NETCOREAPP2_1
+        protected override void HashCore(ReadOnlySpan<byte> source) => seed = CRC.Crc32(source);
+#endif
 
         protected override byte[] HashFinal()
         {


### PR DESCRIPTION
Hi @yubabich
I've been playing with .net core 3 and Span<> so was wanting to avoid allocating byte arrays for calculating CRC hashes so I forked this and added support for this. I don't know if you want this 😃